### PR TITLE
container now working by switching to official tomcat docker images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,7 +51,7 @@ EXPOSE 18080
 RUN apt-get install -y nano telnet w3m
 COPY start_webanno.sh /tmp/
 CMD /tmp/start_webanno.sh
-CMD bash /opt/webanno/bin/startup.shn && tail -f /opt/webanno/logs/catalina.out
+CMD bash /opt/webanno/bin/startup.sh && tail -f /opt/webanno/logs/catalina.out
 # RUN service tomcat7 start
 #CMD service webanno start && tail -f /var/lib/tomcat7/logs/catalina.out && bash /tmp/start_webanno.sh
 # tail -f /var/lib/tomcat7/logs/catalina.out

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,6 +38,6 @@ EXPOSE 18080
 
 RUN apt-get install -y nano telnet w3m
 COPY start_webanno.sh /tmp/
-RUN service tomcat7 start
+# RUN service tomcat7 start
 CMD bash /tmp/webanno start && tail -f /var/lib/tomcat7/logs/catalina.out
 #ENTRYPOINT service webanno start

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM tomcat:7-jre8
 MAINTAINER Florian Kuhn 
 
 RUN apt-get update
-RUN DEBIAN_FRONTEND=noninteractive apt-get install -y wget mysql-server mysql-client
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y wget mysql-server mysql-client tomcat7-user
 
 # Add oracle java 7 repository
 # commented out while using tomcat:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,5 +37,5 @@ EXPOSE 18080
 
 RUN apt-get install -y nano telnet w3m
 COPY start_webanno.sh /tmp/
-CMD ["/bin/sh", "/tmp/start_webanno.sh"]
+CMD  service webanno start && tail -f /var/lib/tomcat7/logs/catalina.out
 #ENTRYPOINT service webanno start

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM debian:squeeze
 MAINTAINER Arne Neumann <nlpdocker.programming@arne.cl>
 
 RUN apt-get update
-RUN  apt-get install -y wget mysql-server mysql-client
+RUN apt-get install -y wget mysql-server mysql-client
 
 COPY create_webanno_db.sql mysql-init tmp/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,9 +17,9 @@ RUN service mysql start && \
 RUN apt-get install -y curl
 
 WORKDIR /opt
-RUN wget --no-check-certificate https://bintray.com/artifact/download/webanno/downloads/webanno-webapp-2.3.0.war
+RUN wget --no-check-certificate https://bintray.com/artifact/download/webanno/downloads/webanno-webapp-2.3.1.war
 
-RUN apt-get install -y tomcat6 tomcat6-user
+RUN apt-get install -y tomcat7 tomcat7-user
 
 RUN tomcat6-instance-create -p 18080 -c 18005 webanno && \
     chown -R www-data /opt/webanno

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 
-FROM debian:squeeze
+FROM ubuntu:14.04
 
 MAINTAINER Arne Neumann <nlpdocker.programming@arne.cl>
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN wget --no-check-certificate https://bintray.com/artifact/download/webanno/do
 
 RUN apt-get install -y tomcat7 tomcat7-user
 
-RUN tomcat6-instance-create -p 18080 -c 18005 webanno && \
+RUN tomcat7-instance-create -p 18080 -c 18005 webanno && \
     chown -R www-data /opt/webanno
 
 COPY webanno_initd /etc/init.d/webanno

--- a/Dockerfile
+++ b/Dockerfile
@@ -51,6 +51,6 @@ EXPOSE 18080
 RUN apt-get install -y nano telnet w3m
 COPY start_webanno.sh /tmp/
 # RUN service tomcat7 start
-CMD service tomcat7 start && tail -f /var/lib/tomcat7/logs/catalina.out && bash /tmp/start_webanno.sh
+CMD service webanno start && tail -f /var/lib/tomcat7/logs/catalina.out && bash /tmp/start_webanno.sh
 # tail -f /var/lib/tomcat7/logs/catalina.out
 #ENTRYPOINT service webanno start

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM tomcat:latest
 MAINTAINER Florian Kuhn 
 
 RUN apt-get update
-RUN apt-get install -y wget mysql-server mysql-client
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y wget mysql-server mysql-client
 
 # Add oracle java 7 repository
 # commented out while using tomcat:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN service mysql start && \
 RUN apt-get install -y curl
 
 WORKDIR /opt
-RUN wget --no-check-certificate https://bintray.com/artifact/download/webanno/downloads/webanno-webapp-2.3.1.war
+RUN wget --no-check-certificate  https://github.com/webanno/webanno/releases/download/webanno-3.0.0-beta-2/webanno-webapp-3.0.0-beta-2.war
 
 RUN apt-get install -y tomcat7 tomcat7-user
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 
 FROM tomcat:7-jre8
 
-MAINTAINER Arne Neumann, Florian Kuhn 
+MAINTAINER Florian Kuhn (https://github.com/fkuhn), Arne Neumann (https://github.com/arne-cl)
 
 RUN apt-get update
 # Install tomcat utilities (we will need tomcat7-instance-create) and mysql

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM ubuntu:14.04.4
+FROM debian:squeeze
 MAINTAINER Arne Neumann <nlpdocker.programming@arne.cl>
 
 RUN apt-get update
-RUN apt-get upgrade
+# RUN apt-get upgrade
 RUN apt-get install -y --force-yes wget mysql-server mysql-client
 
 COPY create_webanno_db.sql mysql-init tmp/

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN tomcat6-instance-create -p 18080 -c 18005 webanno && \
     chown -R www-data /opt/webanno
 
 COPY webanno_initd /etc/init.d/webanno
-RUN mv /opt/webanno-webapp-2.3.0.war /opt/webanno/webapps/webanno.war
+RUN mv /opt/webanno-webapp-2.3.1.war /opt/webanno/webapps/webanno.war
 
 RUN chmod +x /etc/init.d/webanno
 RUN update-rc.d webanno defaults

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,16 @@ MAINTAINER Florian Kuhn <kuhn@ids-mannheim.de>
 RUN apt-get update
 RUN apt-get install -y wget mysql-server mysql-client
 
+# Add oracle java 7 repository
+RUN apt-get -y install software-properties-common
+RUN add-apt-repository ppa:webupd8team/java
+RUN apt-get -y update
+# Accept the Oracle Java license
+RUN echo "oracle-java8-installer shared/accepted-oracle-license-v1-1 boolean true" | debconf-set-selections
+# Install Oracle Java
+RUN apt-get -y install oracle-java8-installer
+
+
 COPY create_webanno_db.sql mysql-init tmp/
 
 RUN service mysql stop
@@ -16,11 +26,12 @@ RUN service mysql start && \
 RUN apt-get install -y curl
 
 WORKDIR /opt
-RUN apt-get install -y tomcat7 tomcat7-user
+
 RUN wget --no-check-certificate  https://github.com/webanno/webanno/releases/download/webanno-3.0.0-beta-2/webanno-webapp-3.0.0-beta-2.war 
 # RUN wget http://tomcat.apache.org/tomcat-7.0-doc/appdev/sample/sample.war -P /var/lib/tomcat7/webapps
 
-
+RUN apt-get install -y tomcat7 tomcat7-user
+RUN echo "JAVA_HOME=/usr/lib/jvm/java-8-oracle" >> /etc/default/tomcat7
 RUN tomcat7-instance-create -p 18080 -c 18005 webanno && \
     chown -R www-data /opt/webanno
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -50,7 +50,8 @@ EXPOSE 18080
 
 RUN apt-get install -y nano telnet w3m
 COPY start_webanno.sh /tmp/
+CMD /tmp/start_webanno.sh
 # RUN service tomcat7 start
-CMD service webanno start && tail -f /var/lib/tomcat7/logs/catalina.out && bash /tmp/start_webanno.sh
+#CMD service webanno start && tail -f /var/lib/tomcat7/logs/catalina.out && bash /tmp/start_webanno.sh
 # tail -f /var/lib/tomcat7/logs/catalina.out
 #ENTRYPOINT service webanno start

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,5 +37,6 @@ EXPOSE 18080
 
 RUN apt-get install -y nano telnet w3m
 COPY start_webanno.sh /tmp/
-CMD  service webanno start && tail -f /var/lib/tomcat7/logs/catalina.out
+CMD ["service webanno", "start"]
+#CMD  ["service webanno start && tail -f /var/lib/tomcat7/logs/catalina.out
 #ENTRYPOINT service webanno start

--- a/Dockerfile
+++ b/Dockerfile
@@ -51,7 +51,7 @@ EXPOSE 18080
 RUN apt-get install -y nano telnet w3m
 COPY start_webanno.sh /tmp/
 CMD /tmp/start_webanno.sh
-CMD bash /opt/webanno/bin/startup.sh
+CMD bash /opt/webanno/bin/startup.shn && tail -f /opt/webanno/logs/catalina.out
 # RUN service tomcat7 start
 #CMD service webanno start && tail -f /var/lib/tomcat7/logs/catalina.out && bash /tmp/start_webanno.sh
 # tail -f /var/lib/tomcat7/logs/catalina.out

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,10 @@ MAINTAINER Florian Kuhn <kuhn@ids-mannheim.de>
 RUN apt-get update
 RUN apt-get install -y wget mysql-server mysql-client
 
+
+
 # Add oracle java 7 repository
+# commented out while using tomcat:latest
 #RUN apt-get -y install software-properties-common
 #RUN add-apt-repository ppa:webupd8team/java
 #RUN apt-get -y update

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:squeeze
+FROM debian:wheezy
 
 MAINTAINER Arne Neumann <nlpdocker.programming@arne.cl>
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,13 +17,13 @@ RUN apt-get install -y curl
 
 WORKDIR /opt
 
-RUN wget --no-check-certificate  https://github.com/webanno/webanno/releases/download/webanno-3.0.0-beta-4/webanno-webapp-3.0.0-beta-2.war 
+RUN wget --no-check-certificate  https://github.com/webanno/webanno/releases/download/webanno-3.0.0-beta-4/webanno-webapp-3.0.0-beta-4.war 
 
 RUN tomcat7-instance-create -p 18080 -c 18005 webanno && \
     chown -R www-data /opt/webanno
 
 COPY webanno_initd /etc/init.d/webanno
-RUN mv /opt/webanno-webapp-3.0.0-beta-2.war /opt/webanno/webapps/webanno.war
+RUN mv /opt/webanno-webapp-3.0.0-beta-4.war /opt/webanno/webapps/webanno.war
 
 RUN chmod +x /etc/init.d/webanno
 RUN update-rc.d webanno defaults

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM scratch
+FROM ubuntu:15.10
 MAINTAINER Arne Neumann <nlpdocker.programming@arne.cl>
-ADD ubuntu-wily-core-cloudimg-amd64-root.tar.gz /
+#ä ADD ubuntu-wily-core-cloudimg-amd64-root.tar.gz /
 
 # a few minor docker-specific tweaks
 # see https://github.com/docker/docker/blob/master/contrib/mkimage/debootstrap

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,30 +1,36 @@
+# This Dockerfile is using parts of the webanno admin guide
+# found in https://webanno.github.io/webanno/releases/2.3.1/docs/admin-guide.html 
+
 FROM tomcat:7-jre8
 
 MAINTAINER Arne Neumann, Florian Kuhn 
 
 RUN apt-get update
+# Install tomcat utilities (we will need tomcat7-instance-create) and mysql
 RUN DEBIAN_FRONTEND=noninteractive apt-get install -y wget mysql-server mysql-client tomcat7-user tomcat7-admin
 
+# Copy webanno and mysql settings to tmp
 COPY create_webanno_db.sql mysql-init /tmp/
 
+# Setup mysql as depicted in the webanno admin guide
 RUN service mysql stop
 RUN mysqld_safe --init-file=/tmp/mysql-init &
 RUN rm /tmp/mysql-init
 RUN service mysql start && \
     mysql -u root < /tmp/create_webanno_db.sql
 
-RUN apt-get install -y curl
-
 WORKDIR /opt
-
+# Download the latest webanno 3 release. change the path accordingly if updated
 RUN wget --no-check-certificate  https://github.com/webanno/webanno/releases/download/webanno-3.0.0-beta-4/webanno-webapp-3.0.0-beta-4.war 
 
+# Create a tomcat7 instance of webanno to operate on port 18080 as
+# shown in the official admin guide
 RUN tomcat7-instance-create -p 18080 -c 18005 webanno && \
     chown -R www-data /opt/webanno
-
+# Rename the webanno webapp 
 COPY webanno_initd /etc/init.d/webanno
 RUN mv /opt/webanno-webapp-3.0.0-beta-4.war /opt/webanno/webapps/webanno.war
-
+# Setup webanno as a service 
 RUN chmod +x /etc/init.d/webanno
 RUN update-rc.d webanno defaults
 RUN mkdir /srv/webanno
@@ -34,5 +40,12 @@ RUN chown -R www-data /srv/webanno
 
 EXPOSE 18080
 
-RUN apt-get install -y nano telnet w3m
-CMD bash /opt/webanno/bin/startup.sh && tail -f /opt/webanno/logs/catalina.out &
+# If you wish minimal some editor, telnet and text-browser functionality
+# for interactive mode in docker, you can uncomment the following line: 
+# RUN apt-get install -y nano telnet w3m
+
+# Start the webanno service and continously tail the tomcat log file output
+# to the shell so the container does not shutdown immediatly after command execution
+# and keeps running. Moreover, log output tells you if everything went ok 
+# The terminal be killed while the container and thus webanno remains active.
+CMD bash /opt/webanno/bin/startup.sh && tail -f /opt/webanno/logs/catalina.out 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM tomcat:7-jre8
 MAINTAINER Florian Kuhn 
 
 RUN apt-get update
-RUN DEBIAN_FRONTEND=noninteractive apt-get install -y wget mysql-server mysql-client tomcat7-user
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y wget mysql-server mysql-client tomcat7-user tomcat7-admin
 
 # Add oracle java 7 repository
 # commented out while using tomcat:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,9 +16,10 @@ RUN service mysql start && \
 RUN apt-get install -y curl
 
 WORKDIR /opt
-RUN wget --no-check-certificate  https://github.com/webanno/webanno/releases/download/webanno-3.0.0-beta-2/webanno-webapp-3.0.0-beta-2.war
-
 RUN apt-get install -y tomcat7 tomcat7-user
+RUN wget --no-check-certificate  https://github.com/webanno/webanno/releases/download/webanno-3.0.0-beta-2/webanno-webapp-3.0.0-beta-2.war 
+# RUN wget http://tomcat.apache.org/tomcat-7.0-doc/appdev/sample/sample.war -P /var/lib/tomcat7/webapps
+
 
 RUN tomcat7-instance-create -p 18080 -c 18005 webanno && \
     chown -R www-data /opt/webanno
@@ -37,6 +38,6 @@ EXPOSE 18080
 
 RUN apt-get install -y nano telnet w3m
 COPY start_webanno.sh /tmp/
-RUN service webanno start
-#CMD service webanno start && tail -f /var/lib/tomcat7/logs/catalina.out
+RUN service tomcat7 start
+CMD bash /tmp/webanno start && tail -f /var/lib/tomcat7/logs/catalina.out
 #ENTRYPOINT service webanno start

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,6 +39,6 @@ EXPOSE 18080
 RUN apt-get install -y nano telnet w3m
 COPY start_webanno.sh /tmp/
 # RUN service tomcat7 start
-CMD bash /tmp/start_webanno.sh
+CMD service tomcat7 start && tail -f /var/lib/tomcat7/logs/catalina.out && bash /tmp/start_webanno.sh
 # tail -f /var/lib/tomcat7/logs/catalina.out
 #ENTRYPOINT service webanno start

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,33 +1,8 @@
-FROM ubuntu:15.10
+FROM ubuntu:14.04.4
 MAINTAINER Arne Neumann <nlpdocker.programming@arne.cl>
-#ä ADD ubuntu-wily-core-cloudimg-amd64-root.tar.gz /
-
-# a few minor docker-specific tweaks
-# see https://github.com/docker/docker/blob/master/contrib/mkimage/debootstrap
-RUN set -xe \
-	\
-	&& echo '#!/bin/sh' > /usr/sbin/policy-rc.d \
-	&& echo 'exit 101' >> /usr/sbin/policy-rc.d \
-	&& chmod +x /usr/sbin/policy-rc.d \
-	\
-	&& dpkg-divert --local --rename --add /sbin/initctl \
-	&& cp -a /usr/sbin/policy-rc.d /sbin/initctl \
-	&& sed -i 's/^exit.*/exit 0/' /sbin/initctl \
-	\
-	&& echo 'force-unsafe-io' > /etc/dpkg/dpkg.cfg.d/docker-apt-speedup \
-	\
-	&& echo 'DPkg::Post-Invoke { "rm -f /var/cache/apt/archives/*.deb /var/cache/apt/archives/partial/*.deb /var/cache/apt/*.bin || true"; };' > /etc/apt/apt.conf.d/docker-clean \
-	&& echo 'APT::Update::Post-Invoke { "rm -f /var/cache/apt/archives/*.deb /var/cache/apt/archives/partial/*.deb /var/cache/apt/*.bin || true"; };' >> /etc/apt/apt.conf.d/docker-clean \
-	&& echo 'Dir::Cache::pkgcache ""; Dir::Cache::srcpkgcache "";' >> /etc/apt/apt.conf.d/docker-clean \
-	\
-	&& echo 'Acquire::Languages "none";' > /etc/apt/apt.conf.d/docker-no-languages \
-	\
-	&& echo 'Acquire::GzipIndexes "true"; Acquire::CompressionTypes::Order:: "gz";' > /etc/apt/apt.conf.d/docker-gzip-indexes
-
-# enable the universe
-RUN sed -i 's/^#\s*\(deb.*universe\)$/\1/g' /etc/apt/sources.list
 
 RUN apt-get update
+RUN apt-get upgrade
 RUN apt-get install -y --force-yes wget mysql-server mysql-client
 
 COPY create_webanno_db.sql mysql-init tmp/

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,13 +25,14 @@ RUN service mysql start && \
 
 RUN apt-get install -y curl
 
+RUN apt-get install -y tomcat7 tomcat7-user
+RUN echo "JAVA_HOME=/usr/lib/jvm/java-8-oracle" >> /etc/default/tomcat7
+
 WORKDIR /opt
 
 RUN wget --no-check-certificate  https://github.com/webanno/webanno/releases/download/webanno-3.0.0-beta-2/webanno-webapp-3.0.0-beta-2.war 
 # RUN wget http://tomcat.apache.org/tomcat-7.0-doc/appdev/sample/sample.war -P /var/lib/tomcat7/webapps
 
-RUN apt-get install -y tomcat7 tomcat7-user
-RUN echo "JAVA_HOME=/usr/lib/jvm/java-8-oracle" >> /etc/default/tomcat7
 RUN tomcat7-instance-create -p 18080 -c 18005 webanno && \
     chown -R www-data /opt/webanno
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ RUN set -xe \
 RUN sed -i 's/^#\s*\(deb.*universe\)$/\1/g' /etc/apt/sources.list
 
 RUN apt-get update
-RUN apt-get install -y wget mysql-server mysql-client
+RUN apt-get install -y --force-yes wget mysql-server mysql-client
 
 COPY create_webanno_db.sql mysql-init tmp/
 
@@ -38,12 +38,12 @@ RUN rm /tmp/mysql-init
 RUN service mysql start && \
     mysql -u root < /tmp/create_webanno_db.sql
 
-RUN apt-get install -y curl
+RUN apt-get install -y --force-yes curl
 
 WORKDIR /opt
 RUN wget --no-check-certificate https://bintray.com/artifact/download/webanno/downloads/webanno-webapp-2.3.1.war
 
-RUN apt-get install -y tomcat7 tomcat7-user
+RUN apt-get install -y --force-yes tomcat7 tomcat7-user
 
 RUN tomcat7-instance-create -p 18080 -c 18005 webanno && \
     chown -R www-data /opt/webanno

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,6 @@ MAINTAINER Florian Kuhn <kuhn@ids-mannheim.de>
 RUN apt-get update
 RUN apt-get install -y wget mysql-server mysql-client
 
-
-
 # Add oracle java 7 repository
 # commented out while using tomcat:latest
 #RUN apt-get -y install software-properties-common
@@ -16,7 +14,6 @@ RUN apt-get install -y wget mysql-server mysql-client
 #RUN echo "oracle-java8-installer shared/accepted-oracle-license-v1-1 boolean true" | debconf-set-selections
 # Install Oracle Java
 #RUN apt-get -y install oracle-java8-installer
-
 
 COPY create_webanno_db.sql mysql-init tmp/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM debian:wheezy
 
-MAINTAINER Arne Neumann <nlpdocker.programming@arne.cl>
+MAINTAINER Florian Kuhn <kuhn@ids-mannheim.de>
 
 RUN apt-get update
 RUN apt-get install -y wget mysql-server mysql-client

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 FROM debian:squeeze
+
 MAINTAINER Arne Neumann <nlpdocker.programming@arne.cl>
 
 RUN apt-get update
-# RUN apt-get upgrade
-RUN apt-get install -y --force-yes wget mysql-server mysql-client
+RUN  apt-get install -y wget mysql-server mysql-client
 
 COPY create_webanno_db.sql mysql-init tmp/
 
@@ -13,14 +13,14 @@ RUN rm /tmp/mysql-init
 RUN service mysql start && \
     mysql -u root < /tmp/create_webanno_db.sql
 
-RUN apt-get install -y --force-yes curl
+RUN apt-get install -y curl
 
 WORKDIR /opt
 RUN wget --no-check-certificate https://bintray.com/artifact/download/webanno/downloads/webanno-webapp-2.3.1.war
 
-RUN apt-get install -y --force-yes tomcat7 tomcat7-user
+RUN apt-get install -y tomcat7 tomcat7-user
 
-RUN tomcat7-instance-create -p 18080 -c 18005 webanno && \
+RUN tomcat6-instance-create -p 18080 -c 18005 webanno && \
     chown -R www-data /opt/webanno
 
 COPY webanno_initd /etc/init.d/webanno
@@ -39,6 +39,3 @@ RUN apt-get install -y nano telnet w3m
 COPY start_webanno.sh /tmp/
 CMD /bin/sh /tmp/start_webanno.sh
 #ENTRYPOINT service webanno start
-
-
-

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,5 +37,5 @@ EXPOSE 18080
 
 RUN apt-get install -y nano telnet w3m
 COPY start_webanno.sh /tmp/
-CMD /bin/sh /tmp/start_webanno.sh
+CMD ["/bin/sh", "/tmp/start_webanno.sh"]
 #ENTRYPOINT service webanno start

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:14.04
+FROM debian:squeeze
 MAINTAINER Arne Neumann <nlpdocker.programming@arne.cl>
 
 RUN apt-get update

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get install -y wget mysql-server mysql-cl
 # Install Oracle Java
 #RUN apt-get -y install oracle-java8-installer
 
-COPY create_webanno_db.sql mysql-init tmp/
+COPY create_webanno_db.sql mysql-init /tmp/
 
 RUN service mysql stop
 RUN mysqld_safe --init-file=/tmp/mysql-init &

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:squeeze
+FROM ubuntu:14.04
 MAINTAINER Arne Neumann <nlpdocker.programming@arne.cl>
 
 RUN apt-get update

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,5 +39,6 @@ EXPOSE 18080
 RUN apt-get install -y nano telnet w3m
 COPY start_webanno.sh /tmp/
 # RUN service tomcat7 start
-CMD bash /tmp/start_webanno.sh && tail -f /var/lib/tomcat7/logs/catalina.out
+CMD bash /tmp/start_webanno.sh
+# tail -f /var/lib/tomcat7/logs/catalina.out
 #ENTRYPOINT service webanno start

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,6 +37,6 @@ EXPOSE 18080
 
 RUN apt-get install -y nano telnet w3m
 COPY start_webanno.sh /tmp/
-CMD ["service webanno", "start"]
-#CMD  ["service webanno start && tail -f /var/lib/tomcat7/logs/catalina.out
+RUN service webanno start
+#CMD service webanno start && tail -f /var/lib/tomcat7/logs/catalina.out
 #ENTRYPOINT service webanno start

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,16 +5,6 @@ MAINTAINER Florian Kuhn
 RUN apt-get update
 RUN DEBIAN_FRONTEND=noninteractive apt-get install -y wget mysql-server mysql-client tomcat7-user tomcat7-admin
 
-# Add oracle java 7 repository
-# commented out while using tomcat:latest
-#RUN apt-get -y install software-properties-common
-#RUN add-apt-repository ppa:webupd8team/java
-#RUN apt-get -y update
-# Accept the Oracle Java license
-#RUN echo "oracle-java8-installer shared/accepted-oracle-license-v1-1 boolean true" | debconf-set-selections
-# Install Oracle Java
-#RUN apt-get -y install oracle-java8-installer
-
 COPY create_webanno_db.sql mysql-init /tmp/
 
 RUN service mysql stop
@@ -25,13 +15,9 @@ RUN service mysql start && \
 
 RUN apt-get install -y curl
 
-#RUN apt-get install -y tomcat7 tomcat7-user
-#RUN echo "JAVA_HOME=/usr/lib/jvm/java-8-oracle" >> /etc/default/tomcat7
-
 WORKDIR /opt
 
 RUN wget --no-check-certificate  https://github.com/webanno/webanno/releases/download/webanno-3.0.0-beta-2/webanno-webapp-3.0.0-beta-2.war 
-# RUN wget http://tomcat.apache.org/tomcat-7.0-doc/appdev/sample/sample.war -P /var/lib/tomcat7/webapps
 
 RUN tomcat7-instance-create -p 18080 -c 18005 webanno && \
     chown -R www-data /opt/webanno
@@ -49,10 +35,5 @@ RUN chown -R www-data /srv/webanno
 EXPOSE 18080
 
 RUN apt-get install -y nano telnet w3m
-COPY start_webanno.sh /tmp/
-CMD /tmp/start_webanno.sh
 CMD bash /opt/webanno/bin/startup.sh && tail -f /opt/webanno/logs/catalina.out
-# RUN service tomcat7 start
-#CMD service webanno start && tail -f /var/lib/tomcat7/logs/catalina.out && bash /tmp/start_webanno.sh
-# tail -f /var/lib/tomcat7/logs/catalina.out
-#ENTRYPOINT service webanno start
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM tomcat:latest
+FROM tomcat:7-jre8
 
 MAINTAINER Florian Kuhn 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:wheezy
+FROM ubuntu:trusty
 
 MAINTAINER Florian Kuhn <kuhn@ids-mannheim.de>
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,5 +39,5 @@ EXPOSE 18080
 RUN apt-get install -y nano telnet w3m
 COPY start_webanno.sh /tmp/
 # RUN service tomcat7 start
-CMD bash /tmp/webanno start && tail -f /var/lib/tomcat7/logs/catalina.out
+CMD bash /tmp/start_webanno.sh && tail -f /var/lib/tomcat7/logs/catalina.out
 #ENTRYPOINT service webanno start

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN apt-get install -y curl
 
 WORKDIR /opt
 
-RUN wget --no-check-certificate  https://github.com/webanno/webanno/releases/download/webanno-3.0.0-beta-2/webanno-webapp-3.0.0-beta-2.war 
+RUN wget --no-check-certificate  https://github.com/webanno/webanno/releases/download/webanno-3.0.0-beta-4/webanno-webapp-3.0.0-beta-2.war 
 
 RUN tomcat7-instance-create -p 18080 -c 18005 webanno && \
     chown -R www-data /opt/webanno

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,4 +35,4 @@ RUN chown -R www-data /srv/webanno
 EXPOSE 18080
 
 RUN apt-get install -y nano telnet w3m
-CMD bash /opt/webanno/bin/startup.sh && tail -f /opt/webanno/logs/catalina.out
+CMD bash /opt/webanno/bin/startup.sh && tail -f /opt/webanno/logs/catalina.out &

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:trusty
+FROM tomcat:latest
 
 MAINTAINER Florian Kuhn <kuhn@ids-mannheim.de>
 
@@ -6,13 +6,13 @@ RUN apt-get update
 RUN apt-get install -y wget mysql-server mysql-client
 
 # Add oracle java 7 repository
-RUN apt-get -y install software-properties-common
-RUN add-apt-repository ppa:webupd8team/java
-RUN apt-get -y update
+#RUN apt-get -y install software-properties-common
+#RUN add-apt-repository ppa:webupd8team/java
+#RUN apt-get -y update
 # Accept the Oracle Java license
-RUN echo "oracle-java8-installer shared/accepted-oracle-license-v1-1 boolean true" | debconf-set-selections
+#RUN echo "oracle-java8-installer shared/accepted-oracle-license-v1-1 boolean true" | debconf-set-selections
 # Install Oracle Java
-RUN apt-get -y install oracle-java8-installer
+#RUN apt-get -y install oracle-java8-installer
 
 
 COPY create_webanno_db.sql mysql-init tmp/
@@ -25,8 +25,8 @@ RUN service mysql start && \
 
 RUN apt-get install -y curl
 
-RUN apt-get install -y tomcat7 tomcat7-user
-RUN echo "JAVA_HOME=/usr/lib/jvm/java-8-oracle" >> /etc/default/tomcat7
+#RUN apt-get install -y tomcat7 tomcat7-user
+#RUN echo "JAVA_HOME=/usr/lib/jvm/java-8-oracle" >> /etc/default/tomcat7
 
 WORKDIR /opt
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM tomcat:7-jre8
 
-MAINTAINER Florian Kuhn 
+MAINTAINER Arne Neumann, Florian Kuhn 
 
 RUN apt-get update
 RUN DEBIAN_FRONTEND=noninteractive apt-get install -y wget mysql-server mysql-client tomcat7-user tomcat7-admin

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,34 @@
-
-FROM ubuntu:15.10
-
+FROM scratch
 MAINTAINER Arne Neumann <nlpdocker.programming@arne.cl>
+ADD ubuntu-wily-core-cloudimg-amd64-root.tar.gz /
+
+# a few minor docker-specific tweaks
+# see https://github.com/docker/docker/blob/master/contrib/mkimage/debootstrap
+RUN set -xe \
+	\
+	&& echo '#!/bin/sh' > /usr/sbin/policy-rc.d \
+	&& echo 'exit 101' >> /usr/sbin/policy-rc.d \
+	&& chmod +x /usr/sbin/policy-rc.d \
+	\
+	&& dpkg-divert --local --rename --add /sbin/initctl \
+	&& cp -a /usr/sbin/policy-rc.d /sbin/initctl \
+	&& sed -i 's/^exit.*/exit 0/' /sbin/initctl \
+	\
+	&& echo 'force-unsafe-io' > /etc/dpkg/dpkg.cfg.d/docker-apt-speedup \
+	\
+	&& echo 'DPkg::Post-Invoke { "rm -f /var/cache/apt/archives/*.deb /var/cache/apt/archives/partial/*.deb /var/cache/apt/*.bin || true"; };' > /etc/apt/apt.conf.d/docker-clean \
+	&& echo 'APT::Update::Post-Invoke { "rm -f /var/cache/apt/archives/*.deb /var/cache/apt/archives/partial/*.deb /var/cache/apt/*.bin || true"; };' >> /etc/apt/apt.conf.d/docker-clean \
+	&& echo 'Dir::Cache::pkgcache ""; Dir::Cache::srcpkgcache "";' >> /etc/apt/apt.conf.d/docker-clean \
+	\
+	&& echo 'Acquire::Languages "none";' > /etc/apt/apt.conf.d/docker-no-languages \
+	\
+	&& echo 'Acquire::GzipIndexes "true"; Acquire::CompressionTypes::Order:: "gz";' > /etc/apt/apt.conf.d/docker-gzip-indexes
+
+# enable the universe
+RUN sed -i 's/^#\s*\(deb.*universe\)$/\1/g' /etc/apt/sources.list
 
 RUN apt-get update
-RUN  apt-get install -y wget mysql-server mysql-client
+RUN apt-get install -y wget mysql-server mysql-client
 
 COPY create_webanno_db.sql mysql-init tmp/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM tomcat:latest
 
-MAINTAINER Florian Kuhn <kuhn@ids-mannheim.de>
+MAINTAINER Florian Kuhn 
 
 RUN apt-get update
 RUN apt-get install -y wget mysql-server mysql-client

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 
-FROM ubuntu:14.04
+FROM ubuntu:15.10
 
 MAINTAINER Arne Neumann <nlpdocker.programming@arne.cl>
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ RUN tomcat7-instance-create -p 18080 -c 18005 webanno && \
     chown -R www-data /opt/webanno
 
 COPY webanno_initd /etc/init.d/webanno
-RUN mv /opt/webanno-webapp-2.3.1.war /opt/webanno/webapps/webanno.war
+RUN mv /opt/webanno-webapp-3.0.0-beta-2.war /opt/webanno/webapps/webanno.war
 
 RUN chmod +x /etc/init.d/webanno
 RUN update-rc.d webanno defaults

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,4 +36,3 @@ EXPOSE 18080
 
 RUN apt-get install -y nano telnet w3m
 CMD bash /opt/webanno/bin/startup.sh && tail -f /opt/webanno/logs/catalina.out
-

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN wget --no-check-certificate https://bintray.com/artifact/download/webanno/do
 
 RUN apt-get install -y tomcat7 tomcat7-user
 
-RUN tomcat6-instance-create -p 18080 -c 18005 webanno && \
+RUN tomcat7-instance-create -p 18080 -c 18005 webanno && \
     chown -R www-data /opt/webanno
 
 COPY webanno_initd /etc/init.d/webanno

--- a/Dockerfile
+++ b/Dockerfile
@@ -51,6 +51,7 @@ EXPOSE 18080
 RUN apt-get install -y nano telnet w3m
 COPY start_webanno.sh /tmp/
 CMD /tmp/start_webanno.sh
+CMD bash /opt/webanno/bin/startup.sh
 # RUN service tomcat7 start
 #CMD service webanno start && tail -f /var/lib/tomcat7/logs/catalina.out && bash /tmp/start_webanno.sh
 # tail -f /var/lib/tomcat7/logs/catalina.out

--- a/README.md
+++ b/README.md
@@ -17,4 +17,4 @@ The service starts with, for example:
 docker run -i -t -p 18080:18080 webanno3
 ```
 
-You can then access the webanno frontend via localhost:18080/webanno 
+You can then access the webanno frontend via **localhost:18080/webanno** 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Installation
 ============
 
-docker build -t webanno https://github.com/nlpdocker/discoursegraphs-docker.git
+docker build -t webanno https://github.com/nlpdocker/webanno-docker.git
 
 Usage
 =====

--- a/README.md
+++ b/README.md
@@ -1,17 +1,20 @@
 Installation
 ============
 
+```shell
 docker build -t webanno3 https://github.com/fkuhn/webanno3-docker.git
-
+```
 or 
-
+```shell
 docker build --no-cache=true -t webanno3 https://github.com/fkuhn/webanno3-docker.git
-
+```
 
 Usage
 =====
-The service starts via:
+The service starts with, for example:
 
- docker run -i -t -p 18080:18080 webanno3
- 
-but is not showing content when going to localhost:1880 in a browser window. 
+```shell
+docker run -i -t -p 18080:18080 webanno3
+```
+
+You can then access the webanno frontend via localhost:18080/webanno 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,6 @@ Usage
 =====
 The service starts via:
 
- docker run -i -t -p --name webanno 18080:18080 webanno3
+ docker run -i -t -p 18080:18080 webanno3
  
 but is not showing content when going to localhost:1880 in a browser window. 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,11 @@ Installation
 
 docker build -t webanno3 https://github.com/fkuhn/webanno3-docker.git
 
+or 
+
+docker build --no-cache=true -t webanno3 https://github.com/fkuhn/webanno3-docker.git
+
+
 Usage
 =====
 

--- a/README.md
+++ b/README.md
@@ -11,4 +11,6 @@ docker build --no-cache=true -t webanno3 https://github.com/fkuhn/webanno3-docke
 Usage
 =====
 
-Unfortunately, this doesn't work yet.
+ docker run -i -t -p 18080:18080 webanno3
+ 
+ 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Installation
 ============
 
-docker build -t webanno https://github.com/nlpdocker/webanno-docker.git
+docker build -t webanno https://github.com/fkuhn/webanno-docker.git
 
 Usage
 =====

--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ docker build --no-cache=true -t webanno3 https://github.com/fkuhn/webanno3-docke
 
 Usage
 =====
+The service starts via:
 
  docker run -i -t -p 18080:18080 webanno3
  
- 
+but is not showing content when going to localhost:1880 in a browser window. 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Installation
 ============
 
-docker build -t webanno https://github.com/fkuhn/webanno-docker.git
+docker build -t webanno3 https://github.com/fkuhn/webanno3-docker.git
 
 Usage
 =====

--- a/README.md
+++ b/README.md
@@ -12,6 +12,6 @@ Usage
 =====
 The service starts via:
 
- docker run -i -t -p 18080:18080 webanno3
+ docker run -i -t -p --name webanno 18080:18080 webanno3
  
 but is not showing content when going to localhost:1880 in a browser window. 

--- a/deprecated/start_webanno.sh
+++ b/deprecated/start_webanno.sh
@@ -1,0 +1,1 @@
+service webanno start && bash

--- a/deprecated/start_webanno.sh
+++ b/deprecated/start_webanno.sh
@@ -1,1 +1,0 @@
-service webanno start && bash

--- a/start_webanno.sh
+++ b/start_webanno.sh
@@ -1,1 +1,0 @@
-service webanno start && bash


### PR DESCRIPTION
Now working.
- needed FROM tomcat:7-8jre
- removed reference to startup script - calling webanno/bin/startup.sh
- to avoid shutdown of container, tomcats logfile catalina.out must be tailed to the shell.
